### PR TITLE
fix: inputfile is actually input variable. Comment on the -R argument…

### DIFF
--- a/pcap_generator_from_csv.py
+++ b/pcap_generator_from_csv.py
@@ -1214,9 +1214,9 @@ if __name__ == '__main__':
     )
 
     print(generate_random)
-    if generate_random != 0:
+    if generate_random != 0: # i.e., if argument -R 1
         headers = generateRandomHeaders(generate_random)
-    else:
-        headers = readFile(inputfile)
+    else: # i.e., if argument -R 0
+        headers = readFile(input)
 
     generateFromHeaders(headers,output)


### PR DESCRIPTION
The `inputfile` variable does not exists at the main call:
![image](https://github.com/user-attachments/assets/3ca88448-6189-4e62-9265-83551b83eef2)

What I did was to rename it to `input`, because `input` is actually being expected as argument of an input file `-i`:
![image](https://github.com/user-attachments/assets/e2b5b14e-d91b-449b-a022-5debad193c99)

Besides that, it should be more apparent to the user (i.e., maybe in the README file) that now the -R argument is set to 1 by default, ignoring user input files.
Furthermore, everything seems to be working perfectly :)